### PR TITLE
Update Yaml::parse call with a string instead of a path

### DIFF
--- a/libraries/swearjar/Tester.php
+++ b/libraries/swearjar/Tester.php
@@ -33,7 +33,7 @@ class Tester {
 	 * @return void
 	 */
 	public function loadFile($path) {
-		$this->_matchers = Yaml::parse($path);
+		$this->_matchers = Yaml::parse(file_get_contents($path));
 	}
 
 	/**


### PR DESCRIPTION
This avoids the deprecation warning when you call Yaml::parse with a path since version 2.2:

```
PHP Deprecated:  The ability to pass file names to the Symfony\Component\Yaml\Yaml::parse method is deprecated since version 2.2 and will be removed in 3.0. Pass the YAML contents of the file instead. in /vendor/symfony/yaml/Symfony/Component/Yaml/Yaml.php on line 58
```
