### PR TITLE
Added an option to hint at what the censored word was

### DIFF
--- a/libraries/swearjar/Tester.php
+++ b/libraries/swearjar/Tester.php
@@ -16,7 +16,7 @@ class Tester {
 	/**
 	 * Constructor
 	 *
-	 * @param string $file 
+	 * @param string $file
 	 */
 	public function __construct($file = null) {
 		if ($file === null) {
@@ -29,7 +29,7 @@ class Tester {
 	/**
 	 * undocumented function
 	 *
-	 * @param string $path 
+	 * @param string $path
 	 * @return void
 	 */
 	public function loadFile($path) {
@@ -39,8 +39,8 @@ class Tester {
 	/**
 	 * undocumented function
 	 *
-	 * @param string $text 
-	 * @param Closure $callback 
+	 * @param string $text
+	 * @param Closure $callback
 	 * @return void
 	 */
 	public function scan($text, \Closure $callback ) {
@@ -72,7 +72,7 @@ class Tester {
 	/**
 	 * Returns true if $text contains profanity
 	 *
-	 * @param string $text 
+	 * @param string $text
 	 * @return boolean
 	 */
 	public function profane($text) {
@@ -89,7 +89,7 @@ class Tester {
 	/**
 	 * undocumented function
 	 *
-	 * @param string $text 
+	 * @param string $text
 	 * @return array
 	 */
 	public function scorecard($text) {
@@ -113,15 +113,21 @@ class Tester {
 	/**
 	 * undocumented function
 	 *
-	 * @param string $text 
+	 * @param string $text
 	 * @return string
 	 */
-	public function censor($text) {
+	public function censor($text, $hint = false) {
 		$censored = $text;
 
-		$this->scan($text, function($word, $index, $types) use (&$censored) {
+		if($hint) {
+			$offset = 1;
+		} else {
+			$offset = 0;
+		}
+
+		$this->scan($text, function($word, $index, $types) use (&$censored, $offset) {
 			$censoredWord = preg_replace('/\S/', '*', $word);
-			$censored = mb_substr($censored, 0, $index) . $censoredWord . mb_substr($censored, $index + mb_strlen($word));
+			$censored = mb_substr($censored, 0, $index + $offset) . mb_substr($censoredWord, $offset) . mb_substr($censored, $index + mb_strlen($word));
 			return true;
 		});
 

--- a/tests/cases/TesterTest.php
+++ b/tests/cases/TesterTest.php
@@ -31,6 +31,10 @@ class TesterTest extends \PHPUnit_Framework_TestCase {
 		$text = $this->tester->censor('John Doe has a massive hard on he is gonna use to fuck everybody');
 		$expected = 'John Doe has a massive **** ** he is gonna use to **** everybody';
 		$this->assertEquals($expected, $text);
+
+		$text = $this->tester->censor('John Doe has a massive hard on he is gonna use to fuck everybody', true);
+		$expected = 'John Doe has a massive h*** o* he is gonna use to f*** everybody';
+		$this->assertEquals($expected, $text);
 	}
 
 	public function testEdgeCases() {

--- a/tests/cases/TesterTest.php
+++ b/tests/cases/TesterTest.php
@@ -32,8 +32,8 @@ class TesterTest extends \PHPUnit_Framework_TestCase {
 		$expected = 'John Doe has a massive **** ** he is gonna use to **** everybody';
 		$this->assertEquals($expected, $text);
 
-		$text = $this->tester->censor('John Doe has a massive hard on he is gonna use to fuck everybody', true);
-		$expected = 'John Doe has a massive h*** o* he is gonna use to f*** everybody';
+		$text = $this->tester->censor('John Doe has a massive hard on he is gonna use to fuck everybody in the ass', true);
+		$expected = 'John Doe has a massive h*** ** he is gonna use to f*** everybody in the a**';
 		$this->assertEquals($expected, $text);
 	}
 


### PR DESCRIPTION
I had the requirement to hint at what the censored word was by showing the first character and censoring the rest. I made it an optional parameter for the censor method to preserve the original behaviour.
